### PR TITLE
auto deploy with travis on tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,10 +27,12 @@ jobs:
     script:
     - find ./ -type d | xargs chmod 755
     - find ./ -name '*.php' | xargs chmod 644
-    - zip -r $ZIP_FILENAME ./ -x "*.git*" -x "*.editorconfig*" -x "*.travis.yml*" -x "*vendor*" -x "composer.*" && mkdir $BUILD_DIR && mv $ZIP_FILENAME $BUILD_DIR/
+    - zip -r $ZIP_FILENAME ./ -x "*.git*" -x "*.editorconfig*" -x "*.travis.yml*" -x "*assets*" -x "*vendor*" -x "composer.*" && mkdir $BUILD_DIR && mv $ZIP_FILENAME $BUILD_DIR/
     before_deploy:
     - mkdir -p $DIST_DIR_S3 && cp $BUILD_DIR/$ZIP_FILENAME $DIST_DIR_S3/$ZIP_FILENAME
     - mkdir -p $DIST_DIR_GITHUB && cp $BUILD_DIR/$ZIP_FILENAME $DIST_DIR_GITHUB/$GITHUB_RELEASE_FILENAME
+    - curl -LO https://raw.githubusercontent.com/bmlt-enabled/bmlt-wordpress-deploy/master/deploy-wordpress.sh
+    - chmod +x deploy-wordpress.sh
     deploy:
     - provider: s3
       access_key_id: AKIAI7JHYFA6DI3WYP5A
@@ -48,6 +50,11 @@ jobs:
       file: "$DIST_DIR_GITHUB/$GITHUB_RELEASE_FILENAME"
       skip_cleanup: true
       name: "$TRAVIS_TAG"
+      on:
+        tags: true
+    - provider: script
+      script: ./deploy-wordpress.sh
+      skip_cleanup: true
       on:
         tags: true
 notifications:


### PR DESCRIPTION
this will auto deploy the plugin to wordpress on tag, I would recomend removing old tags and keeping tags the same as wordpress versions. this uses this script https://github.com/bmlt-enabled/bmlt-wordpress-deploy   and the bmlt-enabled contributor to svn. if tag contains a hyphen `-` in it, it will not deploy to wordpress.